### PR TITLE
Parallel processing of multiple subjects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,4 +65,10 @@ ENV PATH="/usr/local/freesurfer/bin:/usr/local/freesurfer/fsfast/bin:/usr/local/
     MNI_DIR="/usr/local/freesurfer/mni"                     \
     FSF_OUTPUT_FORMAT="nii.gz"
 
+# duct tape programming
+WORKDIR /usr/local/src/pl-fshack
+COPY . .
+RUN pip install .
+WORKDIR $APPROOT
+
 CMD ["fshack.py", "--help"]

--- a/README.rst
+++ b/README.rst
@@ -139,6 +139,11 @@ Arguments
     If specified, print version number and exit.
 
 
+Processing Multiple Subjects
+----------------------------
+
+Starting from ``pl-fshack`` version 1.3.0, when there exists subdirectories within the input directory, where each subdirectory contains subject data, the ``pl-fshack`` program interprets its arguments per-subject subdirectory and each subject is processed in parallel. The maximum number of concurrent subprocesses is limited to the number of logical CPUs visible to the container.
+
 Run
 ----
 

--- a/fshack/_output.py
+++ b/fshack/_output.py
@@ -1,0 +1,70 @@
+from dataclasses import dataclass
+from typing import Collection, AnyStr, IO, ContextManager, TextIO, Iterable
+
+
+@dataclass(frozen=True)
+class MultiSink:
+    """
+    A writable file-like object which writes to multiple other file-like objects.
+    """
+    streams: Collection[IO]
+    """Output streams"""
+
+    def close(self) -> None:
+        for s in self.streams:
+            s.close()
+
+    def write(self, data: AnyStr) -> None:
+        for s in self.streams:
+            s.write(data)
+
+    def writable(self) -> bool:
+        return all(s.writable() for s in self.streams)
+
+    def writelines(self, lines: Iterable[AnyStr]) -> None:
+        for s in self.streams:
+            s.writelines(lines)
+
+    def __enter__(self) -> IO[AnyStr]:
+        for s in self.streams:
+            s.__enter__()
+        return self
+
+    def __exit__(self, t, v, tb):
+        for s in self.streams:
+            s.__exit__(t, v, tb)
+
+
+@dataclass()
+class PrefixedSink(ContextManager):
+    """
+    A writable file-like object which prepends a prefix to every new line of text output.
+    """
+    sink: TextIO
+    """Output stream"""
+    prefix: str
+    """Prefix to print before every line"""
+    __first: bool = True
+    """Whether or not it's necessary to print prefix before printing the next character"""
+
+    def write(self, data: str):
+        for char in data:
+            self._write_char(char)
+
+    def _write_char(self, char: str):
+        """
+        Write a single character to the wrapped output stream,
+        printing out the prefix when necessary.
+        """
+        if self.__first:
+            self.sink.write(self.prefix)
+            self.__first = False
+        self.sink.write(char)
+        if char == '\n':
+            self.__first = True
+
+    def __enter__(self):
+        self.sink.__enter__()
+
+    def __exit__(self, t, v, tb):
+        self.sink.__exit__(t, v, tb)

--- a/fshack/fshack.py
+++ b/fshack/fshack.py
@@ -358,6 +358,7 @@ class Fshack(ChrisApp):
         mapper = PathMapper.dir_mapper_deep(input_dir, output_dir)
         if mapper.is_empty():
             print('WARNING: mapper is empty, assuming base')
+            options.display_prefix = ''
             yield options
             return
         for sub_input, sub_output in mapper:

--- a/fshack/fshack.py
+++ b/fshack/fshack.py
@@ -21,7 +21,7 @@ from typing import Iterator, TextIO
 from pathlib import Path
 from colorama import Fore
 from chris_plugin import PathMapper
-from fshack._output import PrefixedSink, MultiSink
+from _output import PrefixedSink, MultiSink
 
 sys.path.append(os.path.dirname(__file__))
 
@@ -388,7 +388,7 @@ class Fshack(ChrisApp):
         str_cmd = self.create_cmd(options)
         # Run the job and provide realtime stdout
         # and post-run stderr
-        os.mkdir(options.outputdir)
+        os.makedirs(options.outputdir, exist_ok=True)
         m_stdout = MultiSink((
             PrefixedSink(sys.stdout, prefix=options.display_prefix, suffix=Fore.RESET),
             open(f'{options.outputdir}/{options.outputFile}-stdout', 'w')

--- a/fshack/fshack.py
+++ b/fshack/fshack.py
@@ -261,8 +261,6 @@ class Fshack(ChrisApp):
         behaviour. Specifically, if the inputFile spec starts with a
         period, '.', then search the inputDir for the first file with
         that substring and assign that file as inputFile.
-
-        Modify the options variable in place.
         """
         str_thisDir:    str     = ''
         str_pattern:    str     = ''
@@ -273,8 +271,9 @@ class Fshack(ChrisApp):
             os.chdir(options.inputdir)
             l_files         = glob.glob('*' + str_pattern + '*')
             if len(l_files):
-                options.inputFile = l_files[0]
+                return l_files[0]
             os.chdir(str_thisDir)
+        return options.inputFile
 
     def run(self, options):
         """
@@ -287,7 +286,7 @@ class Fshack(ChrisApp):
             print("%20s:  -->%s<--" % (k, v))
         self.options    = options
 
-        self.inputFileSpec_parse(options)
+        options.inputFile = self.inputFileSpec_parse(options)
 
         str_args    = ""
         l_appargs   = options.args.split('ARGS:')

--- a/fshack/tests/test_output.py
+++ b/fshack/tests/test_output.py
@@ -1,0 +1,61 @@
+import unittest
+from io import StringIO
+from fshack._output import MultiSink, PrefixedSink
+
+
+class MultiSinkTests(unittest.TestCase):
+    def test_multi_sink(self):
+        sinks = (StringIO(), StringIO(), StringIO())
+        MultiSink(sinks).write('hello')
+        for sink in sinks:
+            self.assertEqual('hello', sink.getvalue())
+
+
+class PrefixedSinkTests(unittest.TestCase):
+    def test_no_output(self):
+        output = StringIO()
+        sink = PrefixedSink(sink=output, prefix='narrator: ')
+        sink.write('')
+        self.assertEqual('', output.getvalue())
+
+    def test_single_newline(self):
+        output = StringIO()
+        sink = PrefixedSink(sink=output, prefix='narrator: ')
+        sink.write('\n')
+        self.assertEqual('narrator: \n', output.getvalue())
+
+    def test_one_line(self):
+        output = StringIO()
+        sink = PrefixedSink(sink=output, prefix='narrator: ')
+        sink.write('hello how do you do')
+        self.assertEqual('narrator: hello how do you do', output.getvalue())
+
+    def test_two_lines(self):
+        output = StringIO()
+        sink = PrefixedSink(sink=output, prefix='narrator: ')
+        sink.write('hello how do you do\n')
+        sink.write('my name is unknown')
+        expected = 'narrator: hello how do you do\nnarrator: my name is unknown'
+        self.assertEqual(expected, output.getvalue())
+
+    def test_two_lines_with_latency(self):
+        output = StringIO()
+        sink = PrefixedSink(sink=output, prefix='narrator: ')
+        sink.write('hello how do you ')
+        sink.write('do\nmy ')
+        sink.write('name is unknown')
+        expected = 'narrator: hello how do you do\nnarrator: my name is unknown'
+        self.assertEqual(expected, output.getvalue())
+
+    def test_trailing_newline(self):
+        output = StringIO()
+        sink = PrefixedSink(sink=output, prefix='narrator: ')
+        sink.write('hello how do you do\n')
+        sink.write('my name is unknown\n')
+        sink.write('\n')
+        expected = 'narrator: hello how do you do\nnarrator: my name is unknown\nnarrator: \n'
+        self.assertEqual(expected, output.getvalue())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/fshack/tests/test_output.py
+++ b/fshack/tests/test_output.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import Mock
 from io import StringIO
 from fshack._output import MultiSink, PrefixedSink
 
@@ -14,46 +15,68 @@ class MultiSinkTests(unittest.TestCase):
 class PrefixedSinkTests(unittest.TestCase):
     def test_no_output(self):
         output = StringIO()
-        sink = PrefixedSink(sink=output, prefix='narrator: ')
+        sink = PrefixedSink(sink=output, prefix='narrator: ', suffix='!')
         sink.write('')
+        sink.flush()
         self.assertEqual('', output.getvalue())
 
     def test_single_newline(self):
         output = StringIO()
-        sink = PrefixedSink(sink=output, prefix='narrator: ')
+        sink = PrefixedSink(sink=output, prefix='narrator: ', suffix='!')
         sink.write('\n')
-        self.assertEqual('narrator: \n', output.getvalue())
+        self.assertEqual('narrator: !\n', output.getvalue())
+
+        sink.flush()
+        self.assertEqual('narrator: !\n', output.getvalue())
 
     def test_one_line(self):
         output = StringIO()
-        sink = PrefixedSink(sink=output, prefix='narrator: ')
-        sink.write('hello how do you do')
-        self.assertEqual('narrator: hello how do you do', output.getvalue())
+        output.close = Mock()  # prevent buffer from being discarded when closed
+
+        with PrefixedSink(sink=output, prefix='narrator: ', suffix='!') as sink:
+            sink.write('hello how do you do')
+            sink.flush()
+            self.assertEqual('narrator: hello how do you do', output.getvalue())
+
+        self.assertEqual('narrator: hello how do you do!', output.getvalue())
 
     def test_two_lines(self):
         output = StringIO()
-        sink = PrefixedSink(sink=output, prefix='narrator: ')
-        sink.write('hello how do you do\n')
-        sink.write('my name is unknown')
-        expected = 'narrator: hello how do you do\nnarrator: my name is unknown'
+        output.close = Mock()  # prevent buffer from being discarded when closed
+
+        with PrefixedSink(sink=output, prefix='narrator: ', suffix='!') as sink:
+            sink.write('hello how do you do\n')
+            sink.write('my name is unknown')
+            expected = 'narrator: hello how do you do!\n'
+            self.assertEqual(expected, output.getvalue())
+
+        expected = 'narrator: hello how do you do!\nnarrator: my name is unknown!'
         self.assertEqual(expected, output.getvalue())
 
     def test_two_lines_with_latency(self):
         output = StringIO()
-        sink = PrefixedSink(sink=output, prefix='narrator: ')
-        sink.write('hello how do you ')
-        sink.write('do\nmy ')
-        sink.write('name is unknown')
-        expected = 'narrator: hello how do you do\nnarrator: my name is unknown'
+        output.close = Mock()  # prevent buffer from being discarded when closed
+
+        with PrefixedSink(sink=output, prefix='narrator: ', suffix='!') as sink:
+            sink.write('hello how do you ')
+            self.assertEqual('', output.getvalue())
+            sink.write('do\nmy ')
+            self.assertEqual('narrator: hello how do you do!\n', output.getvalue())
+            sink.write('name is unknown')
+            self.assertEqual('narrator: hello how do you do!\n', output.getvalue())
+
+        expected = 'narrator: hello how do you do!\nnarrator: my name is unknown!'
         self.assertEqual(expected, output.getvalue())
 
     def test_trailing_newline(self):
         output = StringIO()
-        sink = PrefixedSink(sink=output, prefix='narrator: ')
+        output.close = Mock()  # prevent buffer from being discarded when closed
+
+        sink = PrefixedSink(sink=output, prefix='narrator: ', suffix='!')
         sink.write('hello how do you do\n')
         sink.write('my name is unknown\n')
         sink.write('\n')
-        expected = 'narrator: hello how do you do\nnarrator: my name is unknown\nnarrator: \n'
+        expected = 'narrator: hello how do you do!\nnarrator: my name is unknown!\nnarrator: !\n'
         self.assertEqual(expected, output.getvalue())
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 chrisapp
 pudb
+chris_plugin==0.0.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 chrisapp
 pudb
 chris_plugin==0.0.17
+colorama~=0.4.4

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ import os
 
 
 # Make sure we are running python3.5+
-if 10 * sys.version_info[0] + sys.version_info[1] < 35:
-    sys.exit("Sorry, only Python 3.5+ is supported.")
+if 10 * sys.version_info[0] + sys.version_info[1] < 38:
+    sys.exit("Sorry, only Python 3.8+ is supported.")
 
 
 from setuptools import setup
@@ -21,7 +21,7 @@ setup(
       name             =   'fshack',
       # for best practices make this version the same as the VERSION class variable
       # defined in your ChrisApp-derived Python class
-      version          =   '1.2.3',
+      version          =   '1.3.0',
       description      =   'A containerized FreeSurfer, with several modes of operation accessible via specific CLI patterning',
       long_description =   readme(),
       author           =   'FNNDSC',


### PR DESCRIPTION
Use [`chris_plugin.PathMapper.dir_mapper_deep`](https://fnndsc.github.io/chris_plugin/chris_plugin.html#PathMapper.dir_mapper_deep) to change the operation of `pl-fshack` so that its functionality is applied to each subject data-containing subdirectory under `options.inputdir`. Subjects are processed in parallel.

To achieve the goal above, the `job_run` function was revamped to use `asyncio` and custom file-like objects for an efficient solution to running a subprocess, showing its output in real-time to both stdout and stderr, while also recording both streams to "log" files in `options.outputdir`.

The output printed to the process' stdout and stderr (typically the console/terminal output) are color-coded and prefixed by the name of the subject's data directory.

Code was changed where necessary to clean up code smells such as global mutable variables, but otherwise, functions such as `inputFileSpec_parse` and the logic which was moved to `create_cmd` were for the most part untouched. Usage of `pl-fshack` version 1.3.0 (this version) should be the same as version 1.2.0 (current version).

